### PR TITLE
intentresolver: Add byte pagination to RequestBatcher and IntentResolver

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -119,6 +119,12 @@ type Config struct {
 	// request. If MaxKeysPerBatchReq <= 0 then no limit is enforced.
 	MaxKeysPerBatchReq int
 
+	// TargetBytesPerBatchReqFn is a function returning the current desired
+	// TargetBytes assigned to the Header of each batch request. If
+	// TargetBytesPerBatchReqFn is nil or TargetBytesPerBatchReqFn() <= 0, then
+	// no TargetBytes is enforced.
+	TargetBytesPerBatchReqFn func() int64
+
 	// MaxWait is the maximum amount of time a message should wait in a batch
 	// before being sent. If MaxWait is <= 0 then no wait timeout is enforced.
 	// It is inadvisable to disable both MaxIdle and MaxWait.
@@ -303,14 +309,14 @@ func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 			}
 		}
 		// Send requests in a loop to support pagination, which may be necessary
-		// if MaxKeysPerBatchReq is set. If so, partial responses with resume
-		// spans may be returned for requests, indicating that the limit was hit
-		// before they could complete and that they should be resumed over the
-		// specified key span. Requests in the batch are neither guaranteed to
-		// be ordered nor guaranteed to be non-overlapping, so we can make no
-		// assumptions about the requests that will result in full responses
-		// (with no resume spans) vs. partial responses vs. empty responses (see
-		// the comment on roachpb.Header.MaxSpanRequestKeys).
+		// if MaxKeysPerBatchReq or TargetBytesPerBatchReq is set. If so, partial
+		// responses with resume spans may be returned for requests, indicating
+		// that the limit was hit before they could complete and that they should
+		// be resumed over the specified key span. Requests in the batch are
+		// neither guaranteed to be ordered nor guaranteed to be non-overlapping,
+		// so we can make no assumptions about the requests that will result in
+		// full responses (with no resume spans) vs. partial responses vs. empty
+		// responses (see the comment on roachpb.Header.MaxSpanRequestKeys).
 		//
 		// To accommodate this, we keep track of all partial responses from
 		// previous iterations. After receiving a batch of responses during an
@@ -551,6 +557,11 @@ func (b *batch) batchRequest(cfg *Config) *roachpb.BatchRequest {
 	}
 	if cfg.MaxKeysPerBatchReq > 0 {
 		req.MaxSpanRequestKeys = int64(cfg.MaxKeysPerBatchReq)
+	}
+	if cfg.TargetBytesPerBatchReqFn != nil {
+		if targetBytesPerBatchReq := cfg.TargetBytesPerBatchReqFn(); targetBytesPerBatchReq > 0 {
+			req.TargetBytes = targetBytesPerBatchReq
+		}
 	}
 	return req
 }

--- a/pkg/internal/client/requestbatcher/batcher_test.go
+++ b/pkg/internal/client/requestbatcher/batcher_test.go
@@ -13,6 +13,7 @@ package requestbatcher
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -576,6 +577,44 @@ func TestMaxKeysPerBatchReq(t *testing.T) {
 	// Make sure everything gets a response.
 	if err := g.Wait(); err != nil {
 		t.Fatalf("expected no errors, got %v", err)
+	}
+}
+
+// TestTargetBytesPerBatchReq checks that the correct TargetBytes limit is set
+// according to the TargetBytesPerBatchReqFn passed in via the config.
+func TestTargetBytesPerBatchReq(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	sc := make(chanSender)
+	var targetBytesPerBatchReq int64
+	targetBytesPerBatchReqFn := func() int64 {
+		return targetBytesPerBatchReq
+	}
+	b := New(Config{
+		// MaxMsgsPerBatch of 1 is chosen so that the first call to Send will
+		// immediately lead to a batch being sent.
+		MaxMsgsPerBatch:          1,
+		Sender:                   sc,
+		Stopper:                  stopper,
+		TargetBytesPerBatchReqFn: targetBytesPerBatchReqFn,
+	})
+	respChan := make(chan Response, 2)
+	targetBytesPerBatchReq = 62 << 20
+	err := b.SendWithChan(context.Background(), respChan, 1, &roachpb.GetRequest{})
+	require.NoError(t, err)
+	select {
+	case s := <-sc:
+		assert.Equal(t, int64(62<<20), s.ba.TargetBytes)
+		s.respChan <- batchResp{}
+	}
+	targetBytesPerBatchReq = 2 << 20
+	err = b.SendWithChan(context.Background(), respChan, 1, &roachpb.GetRequest{})
+	require.NoError(t, err)
+	select {
+	case s := <-sc:
+		assert.Equal(t, int64(2<<20), s.ba.TargetBytes)
+		s.respChan <- batchResp{}
 	}
 }
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -694,7 +694,7 @@ func (ds *DistSender) initAndVerifyBatch(
 				foundReverse = true
 
 			case *roachpb.QueryIntentRequest, *roachpb.EndTxnRequest,
-				*roachpb.GetRequest, *roachpb.DeleteRequest:
+				*roachpb.GetRequest, *roachpb.ResolveIntentRequest, *roachpb.DeleteRequest:
 				// Accepted point requests that can be in batches with limit.
 
 			default:

--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -166,4 +168,144 @@ func TestIntentResolutionUnavailableRange(t *testing.T) {
 			return nil
 		})
 	}
+}
+
+// TestIntentResolutionByteSizePagination tests that intent resolution has byte
+// size pagination. This is done by resolving intents where the total byte size
+// of the intents in the batch exceeds the max raft command size actually
+// cleans up the intents.
+func TestIntentResolutionByteSizePagination(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	const numNodes = 2
+	serverArgs := make(map[int]base.TestServerArgs)
+	for i := 1; i <= numNodes; i++ {
+		serverArgs[i-1] = base.TestServerArgs{
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{
+					{
+						Key: "rack", Value: strconv.Itoa(i),
+					},
+				},
+			},
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
+						TargetBytesPerBatchReq: 2900,
+					},
+				},
+			},
+		}
+	}
+
+	// Start test cluster.
+	clusterArgs := base.TestClusterArgs{
+		ReplicationMode:   base.ReplicationAuto,
+		ServerArgsPerNode: serverArgs,
+	}
+	tc := testcluster.StartTestCluster(t, numNodes, clusterArgs)
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.ServerConn(0)
+
+	// Create 2 tables t1 and t2 and wait for t1 to be replicated on store 1 and
+	// t2 to be replicated on store 2.
+	numTables := 2
+	for i := 1; i <= numTables; i++ {
+		_, err := db.Exec(fmt.Sprintf("CREATE TABLE t%d (i STRING PRIMARY KEY)", i))
+		require.NoError(t, err)
+		_, err = db.Exec(fmt.Sprintf("ALTER TABLE t%d CONFIGURE ZONE USING num_replicas = 1, constraints = '{\"+rack=%d\": 1}'", i, i))
+		require.NoError(t, err)
+	}
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceScanOnAllReplicationQueues(tc); err != nil {
+			return err
+		}
+		for i := 1; i <= numTables; i++ {
+			r := db.QueryRow(fmt.Sprintf("select replicas from [show ranges from table t%d]", i))
+			var repl string
+			if err := r.Scan(&repl); err != nil {
+				return err
+			}
+			if repl != fmt.Sprintf("{%d}", i) {
+				return errors.Newf("Expected replicas {%d} for table t%d, got %s", i, i, repl)
+			}
+		}
+		return nil
+	})
+
+	// Set the max raft command size to 4900.
+	for _, server := range tc.Servers {
+		st := server.ClusterSettings()
+		st.Manual.Store(true)
+		kvserverbase.MaxCommandSize.Override(ctx, &st.SV, 4900)
+	}
+
+	bytes := []byte{'a', 'b', 'c', 'd', 'e'}
+	testKeys := make([][]byte, len(bytes))
+	for i, b := range bytes {
+		testKeys[i] = make([]byte, 1000)
+		for j := range testKeys[i] {
+			testKeys[i][j] = b
+		}
+	}
+
+	// Insert keys and values and commit to generate 5 intents whose keys are
+	// 1000 bytes, which should be batched together and a resolve intent request
+	// will be invoked on this batch.
+	for i, key := range testKeys {
+		_, err := db.Exec("BEGIN")
+		require.NoError(t, err)
+		_, err = db.Exec(fmt.Sprintf("INSERT INTO t1 (i) VALUES ('%s')", []byte{bytes[i]}))
+		require.NoError(t, err)
+
+		_, err = db.Exec(fmt.Sprintf("INSERT INTO t2 (i) VALUES ('%s')", key))
+		require.NoError(t, err)
+		_, err = db.Exec("COMMIT")
+		require.NoError(t, err)
+	}
+
+	// Get the store, start key, and end key of the range containing table t2
+	// which contains the 5 intents whose keys are 1000 bytes.
+	var rangeID roachpb.RangeID
+	var startKey roachpb.Key
+	var endKey roachpb.Key
+	var store *kvserver.Store
+	err := db.QueryRow("select range_id from [show ranges from table t2] limit 1").Scan(&rangeID)
+	require.NoError(t, err)
+	for _, server := range tc.Servers {
+		require.NoError(t, server.Stores().VisitStores(func(s *kvserver.Store) error {
+			if replica, err := s.GetReplica(rangeID); err == nil && replica.OwnsValidLease(ctx, replica.Clock().NowAsClockTimestamp()) {
+				desc := replica.Desc()
+				startKey = desc.StartKey.AsRawKey()
+				endKey = desc.EndKey.AsRawKey()
+				store = s
+			}
+			return nil
+		}))
+	}
+
+	// Check that the 5 intents whose keys are 1000 bytes are eventually
+	// resolved. Note that if byte-size pagination for intent resolution did not
+	// exist, then this batch of intents would not be cleaned up since the batch
+	// contains 5 intents each of size > 1000 bytes, meaning the write batch
+	// resulting from intent resolution would be > 5000 bytes i.e. exceeding the
+	// max raft command size i.e. resolving these intents would fail.
+	testutils.SucceedsSoon(t, func() error {
+		if err != nil {
+			return err
+		}
+		result, err := storage.MVCCScanToBytes(ctx, store.Engine(), startKey, endKey,
+			hlc.MaxTimestamp, storage.MVCCScanOptions{Inconsistent: true})
+		if err != nil {
+			return err
+		}
+		if intentCount := len(result.Intents); intentCount != 0 {
+			return errors.Errorf("%d intents not cleaned up due to intent resolution batch exceeding max raft command size", intentCount)
+		}
+		return nil
+	})
 }

--- a/pkg/kv/kvserver/kvserverbase/knobs.go
+++ b/pkg/kv/kvserver/kvserverbase/knobs.go
@@ -82,4 +82,8 @@ type IntentResolverTestingKnobs struct {
 	// that sending an intent resolution batch request can run for before timing
 	// out.
 	MaxIntentResolutionSendBatchTimeout time.Duration
+
+	// TargetBytesPerBatchReq overrides the maximum number of bytes that an intent
+	// resolution request write batch can be.
+	TargetBytesPerBatchReq int64
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1955,6 +1955,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		AmbientCtx:           s.cfg.AmbientCtx,
 		TestingKnobs:         s.cfg.TestingKnobs.IntentResolverKnobs,
 		RangeDescriptorCache: intentResolverRangeCache,
+		MaxRaftCommandSizeFn: func() int64 {
+			return kvserverbase.MaxCommandSize.Get(&s.cfg.Settings.SV)
+		},
 	})
 	s.metrics.registry.AddMetricStruct(s.intentResolver.Metrics)
 


### PR DESCRIPTION
Fixes: #77228

Intent resolution batches are sequenced on raft and each batch can consist of 100-200 intents. If an intent key or even value in some cases are large, it is possible that resolving all intents in the batch would result in a raft command size exceeding the max raft command size kv.raft.command.max_size.
    
In PR #91976, we added support for TargetBytes for resolve intent and resolve intent range raft commands.
    
In this PR, we set the TargetBytes field in the resolve intent and resolve intent range requests in the RequestBatcher and IntentResolver to half the max raft command size: kv.raft.command.max_size / 2. This allows us to stop resolving intents in the batch as soon as we get close to the max raft command size to lower the chance we exceed this limit.
    
Release note (ops change): Added support for a byte limit on resolve intent and resolve intent range raft commands to prevent such commands from exceeding the max raft command size.