### PR TITLE
storage: Add support for TargetBytes for resolve intent + range cmd

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -93,9 +93,16 @@ func ResolveIntent(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	ok, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update)
+	ok, numBytes, resumeSpan, err := storage.MVCCResolveWriteIntentWithMaxBytes(ctx, readWriter, ms, update, h.TargetBytes)
 	if err != nil {
 		return result.Result{}, err
+	}
+	reply := resp.(*roachpb.ResolveIntentResponse)
+	reply.NumBytes = numBytes
+	if resumeSpan != nil {
+		reply.ResumeSpan = resumeSpan
+		reply.ResumeReason = roachpb.RESUME_BYTE_LIMIT
+		return result.Result{}, nil
 	}
 
 	var res result.Result

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
@@ -52,13 +52,14 @@ func ResolveIntentRange(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	numKeys, resumeSpan, err := storage.MVCCResolveWriteIntentRange(
-		ctx, readWriter, ms, update, h.MaxSpanRequestKeys)
+	numKeys, numBytes, resumeSpan, resumeReason, err := storage.MVCCResolveWriteIntentRangeWithMaxBytes(
+		ctx, readWriter, ms, update, h.MaxSpanRequestKeys, h.TargetBytes)
 	if err != nil {
 		return result.Result{}, err
 	}
 	reply := resp.(*roachpb.ResolveIntentRangeResponse)
 	reply.NumKeys = numKeys
+	reply.NumBytes = numBytes
 	if resumeSpan != nil {
 		update.EndKey = resumeSpan.Key
 		reply.ResumeSpan = resumeSpan
@@ -66,7 +67,7 @@ func ResolveIntentRange(
 		// resolved, not the number of keys scanned. We could return
 		// RESUME_INTENT_LIMIT here, but since the given limit is a key limit we
 		// return RESUME_KEY_LIMIT for symmetry.
-		reply.ResumeReason = roachpb.RESUME_KEY_LIMIT
+		reply.ResumeReason = resumeReason
 	}
 
 	var res result.Result

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -272,6 +272,211 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 	})
 }
 
+// TestResolveIntentWithTargetBytes tests that ResolveIntent and
+// ResolveIntentRange respect the specified TargetBytes i.e. resolve the
+// correct set of intents, return the correct data in the response, and ensure
+// the underlying write batch is the expected size.
+func TestResolveIntentWithTargetBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	ts := hlc.Timestamp{WallTime: 1}
+	bytes := []byte{'a', 'b', 'c', 'd', 'e'}
+	nKeys := len(bytes)
+	testKeys := make([]roachpb.Key, nKeys)
+	values := make([]roachpb.Value, nKeys)
+	for i, b := range bytes {
+		testKeys[i] = make([]byte, 1000)
+		for j := range testKeys[i] {
+			testKeys[i][j] = b
+		}
+		values[i] = roachpb.MakeValueFromBytes([]byte{b})
+	}
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, ts, 0, 1)
+
+	testutils.RunTrueAndFalse(t, "ranged", func(t *testing.T, ranged bool) {
+		db := storage.NewDefaultInMemForTesting()
+		defer db.Close()
+		batch := db.NewBatch()
+		defer batch.Close()
+		st := makeClusterSettingsUsingEngineIntentsSetting(db)
+
+		for i, testKey := range testKeys {
+			err := storage.MVCCPut(ctx, batch, nil, testKey, ts, hlc.ClockTimestamp{}, values[i], &txn)
+			require.NoError(t, err)
+		}
+		initialBytes := batch.Len()
+
+		if !ranged {
+			// Resolve a point intent for testKeys[0].
+			ri := roachpb.ResolveIntentRequest{
+				IntentTxn: txn.TxnMeta,
+				Status:    roachpb.COMMITTED,
+			}
+			ri.Key = testKeys[0]
+
+			{
+				// Case 1: TargetBytes = -1. In this case, we should not resolve any
+				// intents.
+				resp := &roachpb.ResolveIntentResponse{}
+				_, err := ResolveIntent(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &ri,
+						Header: roachpb.Header{
+							TargetBytes: -1,
+						},
+					},
+					resp,
+				)
+				require.NoError(t, err)
+				require.Equal(t, resp.NumBytes, int64(0))
+				require.Equal(t, resp.ResumeSpan.Key, testKeys[0])
+				require.Equal(t, resp.ResumeReason, roachpb.RESUME_BYTE_LIMIT)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Equal(t, numBytes, initialBytes)
+
+				_, _, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				require.Error(t, err)
+			}
+
+			{
+				// Case 2: TargetBytes = 500. In this case, we should resolve the
+				// intent for testKeys[0].
+				resp := &roachpb.ResolveIntentResponse{}
+				_, err := ResolveIntent(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &ri,
+						Header: roachpb.Header{
+							TargetBytes: 500,
+						},
+					},
+					resp,
+				)
+				require.Greater(t, resp.NumBytes, int64(1000))
+				require.Less(t, resp.NumBytes, int64(1100))
+				require.Nil(t, resp.ResumeSpan)
+				require.Equal(t, resp.ResumeReason, roachpb.RESUME_UNKNOWN)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Greater(t, numBytes, initialBytes+1000)
+				require.Less(t, numBytes, initialBytes+1100)
+
+				value, _, err := storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, values[0].RawBytes, value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[0].RawBytes, value.RawBytes)
+			}
+		} else {
+			// Resolve an intent range for testKeys[0], testKeys[1], ...,
+			// testKeys[4].
+			rir := roachpb.ResolveIntentRangeRequest{
+				IntentTxn: txn.TxnMeta,
+				Status:    roachpb.COMMITTED,
+			}
+			rir.Key = testKeys[0]
+			rir.EndKey = testKeys[nKeys-1].Next()
+
+			{
+				// Case 1: TargetBytes = -1. In this case, we should not resolve any
+				// intents.
+				respr := &roachpb.ResolveIntentRangeResponse{}
+				_, err := ResolveIntentRange(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &rir,
+						Header: roachpb.Header{
+							TargetBytes: -1,
+						},
+					},
+					respr,
+				)
+				require.NoError(t, err)
+				require.Equal(t, respr.NumKeys, int64(0))
+				require.Equal(t, respr.NumBytes, int64(0))
+				require.Equal(t, respr.ResumeSpan.Key, testKeys[0])
+				require.Equal(t, respr.ResumeSpan.EndKey, testKeys[nKeys-1].Next())
+				require.Equal(t, respr.ResumeReason, roachpb.RESUME_BYTE_LIMIT)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Equal(t, numBytes, initialBytes)
+
+				_, _, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				require.Error(t, err)
+			}
+
+			{
+				// Case 2: TargetBytes = 2900. In this case, we should resolve the
+				// first 3 intents - testKey[0], testKeys[1], and testKeys[2] (since we
+				// resolve intents until we exceed the TargetBytes limit).
+				respr := &roachpb.ResolveIntentRangeResponse{}
+				_, err := ResolveIntentRange(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &rir,
+						Header: roachpb.Header{
+							TargetBytes: 2900,
+						},
+					},
+					respr,
+				)
+				require.Equal(t, respr.NumKeys, int64(3))
+				require.Greater(t, respr.NumBytes, int64(3000))
+				require.Less(t, respr.NumBytes, int64(3300))
+				require.Equal(t, respr.ResumeSpan.Key, testKeys[2].Next())
+				require.Equal(t, respr.ResumeSpan.EndKey, testKeys[nKeys-1].Next())
+				require.Equal(t, respr.ResumeReason, roachpb.RESUME_BYTE_LIMIT)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Greater(t, numBytes, initialBytes+3000)
+				require.Less(t, numBytes, initialBytes+3300)
+
+				value, _, err := storage.MVCCGet(ctx, batch, testKeys[2], ts, storage.MVCCGetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, values[2].RawBytes, value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[2].RawBytes, value.RawBytes)
+				_, _, err = storage.MVCCGet(ctx, batch, testKeys[3], ts, storage.MVCCGetOptions{})
+				require.Error(t, err)
+			}
+
+			{
+				// Case 3: TargetBytes = 1100 (on remaining intents - testKeys[3] and
+				// testKeys[4]). In this case, we should resolve the remaining
+				// intents - testKey[4] and testKeys[5] (since we resolve intents until
+				// we exceed the TargetBytes limit).
+				respr := &roachpb.ResolveIntentRangeResponse{}
+				_, err := ResolveIntentRange(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &rir,
+						Header: roachpb.Header{
+							TargetBytes: 1100,
+						},
+					},
+					respr,
+				)
+				require.Equal(t, respr.NumKeys, int64(2))
+				require.Greater(t, respr.NumBytes, int64(2000))
+				require.Less(t, respr.NumBytes, int64(2200))
+				require.Nil(t, respr.ResumeSpan)
+				require.Equal(t, respr.ResumeReason, roachpb.RESUME_UNKNOWN)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Greater(t, numBytes, initialBytes+5000)
+				require.Less(t, numBytes, initialBytes+5500)
+
+				value, _, err := storage.MVCCGet(ctx, batch, testKeys[nKeys-1], ts, storage.MVCCGetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, values[nKeys-1].RawBytes, value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[nKeys-1].RawBytes, value.RawBytes)
+			}
+		}
+	})
+}
+
 func makeClusterSettingsUsingEngineIntentsSetting(engine storage.Engine) *cluster.Settings {
 	version := clusterversion.TestingBinaryVersion
 	return cluster.MakeTestingClusterSettingsWithVersions(version, version, true)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -484,6 +484,10 @@ func (s spanSetReader) PinEngineStateForIterators() error {
 	return s.r.PinEngineStateForIterators()
 }
 
+func (s spanSetReader) Len() int {
+	return s.r.Len()
+}
+
 type spanSetWriter struct {
 	w     storage.Writer
 	spans *SpanSet

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2404,15 +2404,26 @@ message Header {
   // complications discussed in "Unordered requests". For now, that's a good
   // enough reason to disallow such batches.
   int64 max_span_request_keys = 8;
+  // TargetBytes will have different behaviour depending on the request type.
+  //
+  // Forward and Reverse Scans:
   // If set to a non-zero value, sets a target (in bytes) for how large the
-  // response may grow. This is only supported for (forward and reverse) scans
-  // and limits the number of rows scanned (and returned). The target will only
-  // be overshot when the first result is larger than the target, unless
+  // response may grow. For forward and reverse scans, TargetBytes limits the
+  // number of rows scanned (and returned). The target will only be overshot
+  // when the first result is larger than the target, unless
   // target_bytes_allow_empty is set. A suitable resume span will be returned.
   //
   // The semantics around overlapping requests, unordered requests, and
   // supported requests from max_span_request_keys apply to the target_bytes
   // option as well.
+  //
+  // Resolve Intent and Resolve Intent Range:
+  // If set to a non-zero value, sets a target (in bytes) for how large the
+  // write batch from intent resolution may grow. For resolve intent and
+  // resolve intent range, TargetBytes limits the number of intents resolved.
+  // We will resolve intents until the number of bytes added to the write batch
+  // by intent resolution exceeds the TargetBytes limit. A suitable resume span
+  // will be returned.
   int64 target_bytes = 15;
   // If positive, Scan and ReverseScan requests with limits (MaxSpanRequestKeys
   // or TargetBytes) will not return results with partial SQL rows at the end

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -598,6 +598,8 @@ type Reader interface {
 	// the first call to PinEngineStateForIterators.
 	// REQUIRES: ConsistentIterators returns true.
 	PinEngineStateForIterators() error
+
+	Len() int
 }
 
 // Writer is the write interface to an engine's data.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3964,11 +3964,31 @@ func MVCCIterate(
 func MVCCResolveWriteIntent(
 	ctx context.Context, rw ReadWriter, ms *enginepb.MVCCStats, intent roachpb.LockUpdate,
 ) (bool, error) {
+	ok, _, _, err := MVCCResolveWriteIntentWithMaxBytes(ctx, rw, ms, intent, 0)
+	return ok, err
+}
+
+// MVCCResolveWriteIntentWithMaxBytes is MVCCResolveWriteIntent but with
+// maxBytes. A maxBytes of -1 means resolve nothing and returns the intent as
+// the resume span. If maxBytes >= 0, then resolve intent and resume span is
+// nil. Returns whether or not an intent was found to resolve, number of bytes
+// added to the write batch by intent resolution, and the resume span.
+func MVCCResolveWriteIntentWithMaxBytes(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	intent roachpb.LockUpdate,
+	maxBytes int64,
+) (bool, int64, *roachpb.Span, error) {
 	if len(intent.Key) == 0 {
-		return false, emptyKeyError()
+		return false, 0, nil, emptyKeyError()
 	}
 	if len(intent.EndKey) > 0 {
-		return false, errors.Errorf("can't resolve range intent as point intent")
+		return false, 0, nil, errors.Errorf("can't resolve range intent as point intent")
+	}
+
+	if maxBytes < 0 {
+		return false, 0, &roachpb.Span{Key: intent.Key}, nil
 	}
 
 	iterAndBuf := GetBufUsingIter(rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
@@ -3976,10 +3996,12 @@ func MVCCResolveWriteIntent(
 		Prefix:   true,
 	}))
 	iterAndBuf.iter.SeekIntentGE(intent.Key, intent.Txn.ID)
+	beforeBytes := rw.Len()
 	ok, err := mvccResolveWriteIntent(ctx, rw, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
+	numBytes := int64(rw.Len() - beforeBytes)
 	// Using defer would be more convenient, but it is measurably slower.
 	iterAndBuf.Cleanup()
-	return ok, err
+	return ok, numBytes, nil, err
 }
 
 // iterForKeyVersions provides a subset of the functionality of MVCCIterator.
@@ -4727,16 +4749,44 @@ func (b IterAndBuf) Cleanup() {
 
 // MVCCResolveWriteIntentRange commits or aborts (rolls back) the range of write
 // intents specified by start and end keys for a given txn.
-// ResolveWriteIntentRange will skip write intents of other txns. A max of zero
-// means unbounded. A max of -1 means resolve nothing and returns the entire
-// intent span as the resume span. Returns the number of intents resolved and a
-// resume span if the max keys limit was exceeded.
+// ResolveWriteIntentRange will skip write intents of other txns. A maxKeys of
+// zero means unbounded. A maxKeys of -1 means resolve nothing and returns the
+// entire intent span as the resume span. Returns the number of intents
+// resolved and a resume span if the max keys limit was exceeded.
 func MVCCResolveWriteIntentRange(
-	ctx context.Context, rw ReadWriter, ms *enginepb.MVCCStats, intent roachpb.LockUpdate, max int64,
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	intent roachpb.LockUpdate,
+	maxKeys int64,
 ) (int64, *roachpb.Span, error) {
-	if max < 0 {
+	numKeys, _, resumeSpan, _, err := MVCCResolveWriteIntentRangeWithMaxBytes(ctx, rw, ms, intent, maxKeys, 0)
+	return numKeys, resumeSpan, err
+}
+
+// MVCCResolveWriteIntentRangeWithMaxBytes is MVCCResolveWriteIntentRange but
+// with maxBytes. A maxBytes of 0 means no byte limit. A maxBytes of -1 means
+// resolve nothing and returns the entire intent span as the resume span. If
+// maxBytes > 0, then resolve intents in the range until the number of bytes
+// added to the write batch by intent resolution exceeds maxBytes. Returns the
+// number of intents resolved, number of bytes added to the write batch by
+// intent resolution, the resume span, and the resume reason.
+func MVCCResolveWriteIntentRangeWithMaxBytes(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	intent roachpb.LockUpdate,
+	maxKeys, maxBytes int64,
+) (int64, int64, *roachpb.Span, roachpb.ResumeReason, error) {
+	keysExceededCond := maxKeys < 0
+	bytesExceededCond := maxBytes < 0
+	if keysExceededCond || bytesExceededCond {
 		resumeSpan := intent.Span // don't inline or `intent` would escape to heap
-		return 0, &resumeSpan, nil
+		resumeReason := roachpb.RESUME_BYTE_LIMIT
+		if keysExceededCond {
+			resumeReason = roachpb.RESUME_KEY_LIMIT
+		}
+		return 0, 0, &resumeSpan, resumeReason, nil
 	}
 	ltStart, _ := keys.LockTableSingleKey(intent.Key, nil)
 	ltEnd, _ := keys.LockTableSingleKey(intent.EndKey, nil)
@@ -4773,25 +4823,32 @@ func MVCCResolveWriteIntentRange(
 	intent.EndKey = nil
 
 	var lastResolvedKey roachpb.Key
-	num := int64(0)
+	var numKeys int64
+	var numBytes int64
 	for {
 		if valid, err := sepIter.Valid(); err != nil {
-			return 0, nil, err
+			return 0, 0, nil, roachpb.RESUME_UNKNOWN, err
 		} else if !valid {
 			// No more intents in the given range.
 			break
 		}
-		if max > 0 && num == max {
+		keysExceededCond = maxKeys > 0 && numKeys == maxKeys
+		bytesExceededCond = maxBytes > 0 && numBytes >= maxBytes
+		if keysExceededCond || bytesExceededCond {
+			resumeReason := roachpb.RESUME_BYTE_LIMIT
+			if keysExceededCond {
+				resumeReason = roachpb.RESUME_KEY_LIMIT
+			}
 			// We could also compute a tighter nextKey here if we wanted to.
-			return num, &roachpb.Span{Key: lastResolvedKey.Next(), EndKey: intentEndKey}, nil
+			return numKeys, numBytes, &roachpb.Span{Key: lastResolvedKey.Next(), EndKey: intentEndKey}, resumeReason, nil
 		}
 		// Parse the MVCCMetadata to see if it is a relevant intent.
 		meta := &putBuf.meta
 		if err := sepIter.ValueProto(meta); err != nil {
-			return 0, nil, err
+			return 0, 0, nil, roachpb.RESUME_UNKNOWN, err
 		}
 		if meta.Txn == nil {
-			return 0, nil, errors.Errorf("intent with no txn")
+			return 0, 0, nil, roachpb.RESUME_UNKNOWN, errors.Errorf("intent with no txn")
 		}
 		if intent.Txn.ID != meta.Txn.ID {
 			// Intent for a different txn, so ignore.
@@ -4807,15 +4864,17 @@ func MVCCResolveWriteIntentRange(
 		// subsequent iteration to construct a resume span.
 		lastResolvedKey = append(lastResolvedKey[:0], sepIter.UnsafeKey().Key...)
 		intent.Key = lastResolvedKey
+		beforeBytes := rw.Len()
 		ok, err := mvccResolveWriteIntent(ctx, rw, sepIter, ms, intent, putBuf)
 		if err != nil {
 			log.Warningf(ctx, "failed to resolve intent for key %q: %+v", lastResolvedKey, err)
 		} else if ok {
-			num++
+			numKeys++
+			numBytes += int64(rw.Len() - beforeBytes)
 		}
 		sepIter.nextEngineKey()
 	}
-	return num, nil, nil
+	return numKeys, numBytes, nil, roachpb.RESUME_UNKNOWN, nil
 }
 
 // MVCCGarbageCollect creates an iterator on the ReadWriter. In parallel

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1841,6 +1841,11 @@ func (p *Pebble) MinVersionIsAtLeastTargetVersion(target roachpb.Version) (bool,
 	return MinVersionIsAtLeastTargetVersion(p.unencryptedFS, p.path, target)
 }
 
+// Len is not supported for Pebble.
+func (p *Pebble) Len() int {
+	return 0
+}
+
 type pebbleReadOnly struct {
 	parent *Pebble
 	// The iterator reuse optimization in pebbleReadOnly is for servicing a
@@ -2043,6 +2048,11 @@ func (p *pebbleReadOnly) PinEngineStateForIterators() error {
 	return nil
 }
 
+// Len is not supported for pebbleReadOnly.
+func (p *pebbleReadOnly) Len() int {
+	return 0
+}
+
 // Writer methods are not implemented for pebbleReadOnly. Ideally, the code
 // could be refactored so that a Reader could be supplied to evaluateBatch
 
@@ -2220,6 +2230,11 @@ func (p *pebbleSnapshot) SupportsRangeKeys() bool {
 func (p *pebbleSnapshot) PinEngineStateForIterators() error {
 	// Snapshot already pins state, so nothing to do.
 	return nil
+}
+
+// Len is not supported by pebbleSnapshot.
+func (p *pebbleSnapshot) Len() int {
+	return 0
 }
 
 // ExceedMaxSizeError is the error returned when an export request


### PR DESCRIPTION
Informs: #77228

Intent resolution batches are sequenced on raft and each batch can consist of 100-200 intents. If an intent key or even value in some cases are large, it is possible that resolving all intents in the batch would result in a raft command size exceeding the max raft command size kv.raft.command.max_size.
    
To address this, we add support for TargetBytes in resolve intent and resolve intent range commands, allowing us to stop resolving intents in the batch as soon as we exceed the TargetBytes max bytes limit.
    
Adding support for byte size pagination for intent resolver and RequestBatcher will be added in a separate PR.
    
Release note (ops change): Added support for a byte limit on resolve intent and resolve intent range raft commands to prevent such commands from exceeding the max raft command size.